### PR TITLE
Add draft implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
 
 Style/StringLiterals:
   Enabled: true

--- a/lib/uid2.rb
+++ b/lib/uid2.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "uid2/version"
-require_relative 'uid2/client'
+require_relative "uid2/client"

--- a/lib/uid2.rb
+++ b/lib/uid2.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "uid2/version"
-
-module Uid2
-  class Error < StandardError; end
-  # Your code goes here...
-end
+require_relative 'uid2/client'

--- a/lib/uid2/client.rb
+++ b/lib/uid2/client.rb
@@ -13,30 +13,66 @@ module Uid2
       self.base_url ||= 'https://integ.uidapi.com/v1/'
     end
 
-    def generate_token(params)
-      http.get('token/generate', params)
+    def generate_token(email: nil, email_hash: nil)
+      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
+
+      # As stated in doc, if email and email_hash are both supplied in the same request,
+      # only the email will return a mapping response.
+      params = unless email.empty?
+                 { email: email }
+               else
+                 { email_hash: email_hash }
+               end
+      http.get('token/generate', params).body
     end
 
-    def validate_token(params)
-      http.get('token/validate', params)
+    def validate_token(token:, email: nil, email_hash: nil)
+      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
+      params = unless email.empty?
+                 { email: email }
+               else
+                 { email_hash: email_hash }
+               end
+
+      http.get('token/validate', params.merge(token: token)).body
     end
 
-    def refresh_token(token)
-      http.get('token/refresh', { refresh_token: token })
+    def refresh_token(refresh_token:)
+      http.get('token/refresh', { refresh_token: refresh_token }).body
     end
 
-    def get_salt_buckets(since = Time.now)
+    def get_salt_buckets(since: Time.now)
       # By default, Ruby's iso8601 generates timezone parts (`T`)
       # which needs to be removed for UID2 APIs
-      http.get('identity/buckets', since_timestamp: since.utc.iso8601[0..-2])
+      http.get('identity/buckets', since_timestamp: since.utc.iso8601[0..-2]).body
     end
 
-    def generate_identifier(params)
-      http.get('identity/map', params)
+    def generate_identifier(email: nil, email_hash: nil)
+      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
+
+      # As stated in doc, if email and email_hash are both supplied in the same request,
+      # only the email will return a mapping response.
+      params = unless email.empty?
+                 { email: email }
+               else
+                 { email_hash: email_hash }
+               end
+
+      http.get('identity/map', params).body
     end
 
-    def batch_generate_identifier(params)
-      http.post('identity/map', params)
+    def batch_generate_identifier(email: nil, email_hash: nil)
+      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
+
+      # As stated in doc, if email and email_hash are both supplied in the same request,
+      # only the email will return a mapping response.
+      params = unless email.empty?
+                 { email: Array(email) }
+               else
+                 { email_hash: Array(email_hash) }
+               end
+
+      http.post('identity/map', params).body
     end
 
     private

--- a/lib/uid2/client.rb
+++ b/lib/uid2/client.rb
@@ -1,78 +1,81 @@
-require 'net/http/persistent'
-require 'faraday'
-require 'faraday_middleware'
-require 'time'
+# frozen_string_literal: true
+
+require "net/http/persistent"
+require "faraday"
+require "faraday_middleware"
+require "time"
 
 module Uid2
   class Client
     attr_accessor :bearer_token, :base_url
 
-    def initialize(options = {})
+    def initialize(_options = {})
       yield(self) if block_given?
 
-      self.base_url ||= 'https://integ.uidapi.com/v1/'
+      self.base_url ||= "https://integ.uidapi.com/v1/"
     end
 
     def generate_token(email: nil, email_hash: nil)
-      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
+      raise ArgumentError, "Either email or email_hash needs to be provided" if email.nil? && email_hash.nil?
 
       # As stated in doc, if email and email_hash are both supplied in the same request,
       # only the email will return a mapping response.
-      params = unless email.empty?
-                 { email: email }
-               else
+      params = if email.empty?
                  { email_hash: email_hash }
+               else
+                 { email: email }
                end
-      http.get('token/generate', params).body
+      http.get("token/generate", params).body
     end
 
     def validate_token(token:, email: nil, email_hash: nil)
-      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
-      params = unless email.empty?
-                 { email: email }
-               else
+      raise ArgumentError, "Either email or email_hash needs to be provided" if email.nil? && email_hash.nil?
+
+      params = if email.empty?
                  { email_hash: email_hash }
+               else
+                 { email: email }
                end
 
-      http.get('token/validate', params.merge(token: token)).body
+      http.get("token/validate", params.merge(token: token)).body
     end
 
     def refresh_token(refresh_token:)
-      http.get('token/refresh', { refresh_token: refresh_token }).body
+      http.get("token/refresh", { refresh_token: refresh_token }).body
     end
 
     def get_salt_buckets(since: Time.now)
       # By default, Ruby's iso8601 generates timezone parts (`T`)
       # which needs to be removed for UID2 APIs
-      http.get('identity/buckets', since_timestamp: since.utc.iso8601[0..-2]).body
+      http.get("identity/buckets", since_timestamp: since.utc.iso8601[0..-2]).body
     end
 
     def generate_identifier(email: nil, email_hash: nil)
-      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
+      raise ArgumentError, "Either email or email_hash needs to be provided" if email.nil? && email_hash.nil?
 
       # As stated in doc, if email and email_hash are both supplied in the same request,
       # only the email will return a mapping response.
-      params = unless email.empty?
-                 { email: email }
-               else
+      params = if email.empty?
                  { email_hash: email_hash }
+               else
+                 { email: email }
                end
 
-      http.get('identity/map', params).body
+      http.get("identity/map", params).body
     end
 
     def batch_generate_identifier(email: nil, email_hash: nil)
-      raise ArgumentError, 'Either email or email_hash needs to be provided' if email.nil? && email_hash.nil?
+      raise ArgumentError, "Either email or email_hash needs to be provided" if email.nil? && email_hash.nil?
 
       # As stated in doc, if email and email_hash are both supplied in the same request,
       # only the email will return a mapping response.
-      params = unless email.empty?
-                 { email: Array(email) }
-               else
+      params = if email.empty?
                  { email_hash: Array(email_hash) }
+               else
+                 { email: Array(email) }
                end
 
-      http.post('identity/map', params).body
+      http.post("identity/map", params).body
     end
 
     private

--- a/lib/uid2/client.rb
+++ b/lib/uid2/client.rb
@@ -1,0 +1,65 @@
+require 'net/http/persistent'
+require 'faraday'
+require 'faraday_middleware'
+require 'time'
+
+module Uid2
+  class Client
+    attr_accessor :bearer_token, :base_url
+
+    def initialize(options = {})
+      yield(self) if block_given?
+
+      self.base_url ||= 'https://integ.uidapi.com/v1/'
+    end
+
+    def generate_token(params)
+      http.get('token/generate', params)
+    end
+
+    def validate_token(params)
+      http.get('token/validate', params)
+    end
+
+    def refresh_token(token)
+      http.get('token/refresh', { refresh_token: token })
+    end
+
+    def get_salt_buckets(since = Time.now)
+      # By default, Ruby's iso8601 generates timezone parts (`T`)
+      # which needs to be removed for UID2 APIs
+      http.get('identity/buckets', since_timestamp: since.utc.iso8601[0..-2])
+    end
+
+    def generate_identifier(params)
+      http.get('identity/map', params)
+    end
+
+    def batch_generate_identifier(params)
+      http.post('identity/map', params)
+    end
+
+    private
+
+    def credentials
+      {
+        "Authorization" => "Bearer #{bearer_token}"
+      }
+    end
+
+    def http
+      @http ||= Faraday.new(
+        url: base_url,
+        headers: credentials
+      ) do |f|
+        f.request :json
+
+        f.response :raise_error
+        f.response :mashify
+        f.response :json
+
+        f.adapter :net_http_persistent
+      end
+    end
+  end
+end

--- a/uid2.gemspec
+++ b/uid2.gemspec
@@ -8,30 +8,25 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Richard Lee"]
   spec.email         = ["14349+dlackty@users.noreply.github.com"]
 
-  spec.summary       = "TODO: Write a short summary, because RubyGems requires one."
-  spec.description   = "TODO: Write a longer description or delete this line."
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = "Ruby API client for Unified ID 2.0"
+  spec.description   = spec.summary
+  spec.homepage      = "https://github.com/polydice/uid2"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "https://github.com/polydice/uid2/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, checkout our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency "faraday", ">= 1"
+  spec.add_dependency "faraday_middleware", ">= 1"
+  spec.add_dependency "hashie", ">= 4"
+  spec.add_dependency "net-http-persistent", ">= 4"
 end

--- a/uid2.gemspec
+++ b/uid2.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/polydice/uid2"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
## Goal

Add a draft implementation based on [Unified ID 2.0's API documentation](https://github.com/UnifiedID2/uid2docs/tree/main/api/v1/endpoints).

## Considerations

1. To simplify the code logic, faraday and middlewares are added as dependencies
2. For common uses cases, user of this project might use API client to consequent API calls, so net-http-persistent is added

## Todos

- [x] Properly handling and validation for API arguments

## Discussions

- [x] What's the right way to pass API arguments? Currently, positional arguments and hash as argument are both used in this project. Should we switch to keyword arguments?